### PR TITLE
fix calling of original command by using "$@"

### DIFF
--- a/src/remora
+++ b/src/remora
@@ -110,7 +110,7 @@ fi
 #export LD_PRELOAD=$REMORA_BIN/../lib/libmpiP.so
 #export MPIP="-f $REMORA_OUTDIR"
 START=$(date +%s%N)
-$@
+"$@"
 END=$(date +%s%N)
 $REMORA_BIN/scripts/remora_finalize.sh $END $START
 


### PR DESCRIPTION
To make sure that the original command is called correctly, you must use `"$@"` rather than just `$@`, see also http://wiki.bash-hackers.org/scripting/posparams#mass_usage .
This is required for command that use quoted arguments.

Example (without this patch):

```
$ remora python -m timeit -n 3 -r 3 -s "import numpy; x = numpy.random.random((6000, 6000)); numpy.dot(x, x.T)"
Traceback (most recent call last):
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.5.2-foss-2016b/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.5.2-foss-2016b/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.5.2-foss-2016b/lib/python3.5/timeit.py", line 337, in <module>
    sys.exit(main())
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.5.2-foss-2016b/lib/python3.5/timeit.py", line 295, in main
    t = Timer(stmt, setup, timer)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/3.5.2-foss-2016b/lib/python3.5/timeit.py", line 111, in __init__
    compile(setup, dummy_src_name, "exec")
  File "<timeit-src>", line 1
    import
         ^
SyntaxError: invalid syntax

=============================== REMORA SUMMARY ===============================
 Max Memory Used Per Node     : 1.44 GB
 Total Elapsed Time           : 0d 0h 0m 0s 166ms
==============================================================================
 Sampling Period              : 10 seconds
 Complete Report Data         : /user/home/gent/vsc400/vsc40023/data/remora_1485533878
==============================================================================
```

with this patch it works as expected:

```
$ remora python -m timeit -n 3 -r 3 -s "import numpy; x = numpy.random.random((6000, 6000)); numpy.dot(x, x.T)"
3 loops, best of 3: 1.65 usec per loop

=============================== REMORA SUMMARY ===============================
 Max Memory Used Per Node     : 2.47 GB
 Total Elapsed Time           : 0d 0h 0m 4s 520ms
==============================================================================
 Sampling Period              : 10 seconds
 Complete Report Data         : /user/home/gent/vsc400/vsc40023/data/remora_1485533971
==============================================================================
```