### PR TITLE
Memory plot, finalize wait and existing remora check

### DIFF
--- a/src/modules/memory
+++ b/src/modules/memory
@@ -126,11 +126,11 @@ plot_data_memory()
     printf "%s \n" "]);" >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
    
     printf "%s \n" "var options = { " >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
-    printf "%s \n" "title : 'Memory Utilization'," >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
+    printf "%s \n" "title : 'Memory Utilization (RMEM and SHMEM are stacked, to show total physical memory)'," >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
     printf "%s \n" "vAxis: {title: 'GB'}," >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
     printf "%s \n" "hAxis: {title: 'Time (s)'}," >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
     printf "%s \n" "isStacked: true," >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
-    printf "%s \n" "series: { 0: {type: 'line', color:'red', lineDashStyle: [1, 1]}, 2: {type: 'line', color:'green', lineDashStyle: [1, 1]}, 5: {type: 'line',lineWidth:5}, 6: {type: 'line', color:'yellow'}},
+    printf "%s \n" "series: { 0: {type: 'line', color:'red', lineDashStyle: [1, 1]}, 1: {type: 'line', color:'orange',lineWidth:3, lineDashStyle: [1, 1]},  2: {type: 'line', color:'green', lineDashStyle: [1, 1]}, 5: {type: 'line',lineWidth:5}, 6: {type: 'line', color:'yellow'}},
     " >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html
     
     printf "%s \n" "width: 1024, " >> $REMORA_TMPDIR/memory_${REMORA_NODE}.html 

--- a/src/remora
+++ b/src/remora
@@ -88,7 +88,7 @@ trap "exit_clean" TERM SIGINT
 #Save the PID of REMORA in case we need it
 export REMORA_TOP_PID=$$
 
-remora_pids=`pgrep remora`
+remora_pids=`pgrep -x remora`
 
 for pid in $remora_pids; do
     if [ $pid != $REMORA_TOP_PID ]; then

--- a/src/scripts/remora_finalize.sh
+++ b/src/scripts/remora_finalize.sh
@@ -93,13 +93,17 @@ function remora_finalize() {
     fi
 
     #Wait until all remora_remote_post processes have finished
+
+    idx=0
     for pid in "${FINAL_PID[@]}"; do
-        while [ -e /proc/$pid ]; do
+        NODE=${NODES[$idx]}
+        while [ `ssh $NODE "[ -e /proc/$pid ] && echo 1"` ]; do
             sleep 0.05
             if [ "$REMORA_VERBOSE" == "1" ]; then
                 printf "."
             fi
         done
+        idx=$((idx+1))
     done
 
     #Add a small delay so that files are transferred (deal with Lustre latency)


### PR DESCRIPTION
Virtual memory was being stacked with Resident and Shared memory in the plot.  Now only Resident and Shared memory are stacked (in modules/memory).

A wait in remora_finalize.sh was waiting on local pid (from FINAL_PID), but these are remote pids and require an ssh.  (This might consume a lot of time for large jobs.  Maybe the completion should be 
signaled by the remote process.)

In remora "pgrep remora" look for an existing remora, and stops if found.  I've included -x  so that it will only search for "remora", and not anything similar (like my_remora_test_executable).